### PR TITLE
Support current rector releases and PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Example:
 
 ```php
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->services()
-        ->set(HtmlOutputFormatter::class)
-        ->arg('$exportedFilePathPrefix', __DIR__ . '/rector-report')
-        ->autowire()
-        ->autoconfigure();
+    $rectorConfig->singleton(HtmlOutputFormatter::class, HtmlOutputFormatter::class);
+    $rectorConfig->tag(HtmlOutputFormatter::class, OutputFormatterInterface::class);
+    $rectorConfig->when(HtmlOutputFormatter::class)
+        ->needs('$exportedFilePathPrefix')
+        ->give(__DIR__ . '/rector-report');
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "rector/rector": "0.*"
     },
     "autoload": {

--- a/src/HtmlOutputFormatter.php
+++ b/src/HtmlOutputFormatter.php
@@ -45,8 +45,6 @@ final class HtmlOutputFormatter implements OutputFormatterInterface
         $errorsJson = [
             'totals' => [
                 'changed_files' => count($processResult->getFileDiffs()),
-                'removed_and_added_files_count' => $processResult->getRemovedAndAddedFilesCount(),
-                'removed_node_count' => $processResult->getRemovedNodeCount()
             ]
         ];
 

--- a/src/HtmlOutputFormatter.php
+++ b/src/HtmlOutputFormatter.php
@@ -68,7 +68,7 @@ final class HtmlOutputFormatter implements OutputFormatterInterface
             // for Rector CI
             $errorsJson['changed_files'][] = $relativeFilePath;
         }
-        $errors = $processResult->getErrors();
+        $errors = $processResult->getSystemErrors();
         $errorsJson['totals']['errors'] = count($errors);
         $errorsData = $this->createErrorsData($errors);
         if ($errorsData !== []) {


### PR DESCRIPTION
Nice project. It seems the OutputFormatterInterface isn't considered stable and so this is broken in current releases. I've patched it up.

Also the container underlying RectorConfig was changed from Symfony's to Laravel's, so the configuration process has changed. I've also fixed the example in the README to reflect.

Also enable use with PHP8+.